### PR TITLE
ScanCommitsJob is no longer triggered when there are no file patterns…

### DIFF
--- a/coderadar-server/coderadar-core/local.application.properties
+++ b/coderadar-server/coderadar-core/local.application.properties
@@ -1,0 +1,26 @@
+# Copy this file into a file named "local.application.properties", edit the properties for your
+# local environment and then call "gradlew bootrun"' to start up the application.
+
+coderadar.master=true
+coderadar.slave=true
+coderadar.scanIntervalInSeconds=30
+coderadar.workdir=coderadar-workdir
+coderadar.dateLocale=de_DE
+coderadar.authentication.accessToken.durationInMinutes=15
+coderadar.authentication.refreshToken.durationInMinutes=86400
+coderadar.authentication.enabled=false
+
+logging.level.org.wickedsource.coderadar=DEBUG
+logging.level.org.wickedsource.coderadar.job.JobLogger=INFO
+logging.level.org.hibernate.SQL=ERROR
+logging.level.org.hibernate.type=ERROR
+logging.level.org.reflections=ERROR
+logging.file=coderadar.log
+
+spring.jpa.hibernate.ddl-auto=validate
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/coderadar
+spring.datasource.username=coderadar
+spring.datasource.password=coderadar
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/analyzerconfig/domain/AnalyzerConfigurationRepository.java
+++ b/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/analyzerconfig/domain/AnalyzerConfigurationRepository.java
@@ -17,4 +17,6 @@ public interface AnalyzerConfigurationRepository
   AnalyzerConfiguration findByProjectIdAndId(Long projectId, Long analyzerConfigurationId);
 
   int deleteByProjectId(Long id);
+
+  int countByProjectId(Long projectId);
 }

--- a/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/filepattern/domain/FilePatternRepository.java
+++ b/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/filepattern/domain/FilePatternRepository.java
@@ -10,4 +10,6 @@ public interface FilePatternRepository extends CrudRepository<FilePattern, Long>
   List<FilePattern> findByProjectIdAndFileSetType(Long projectId, FileSetType fileSetType);
 
   int deleteByProjectId(Long projectId);
+
+  int countByProjectId(Long projectId);
 }

--- a/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/job/analyze/AnalyzeCommitJobTrigger.java
+++ b/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/job/analyze/AnalyzeCommitJobTrigger.java
@@ -2,13 +2,17 @@ package org.wickedsource.coderadar.job.analyze;
 
 import java.util.Arrays;
 import java.util.Date;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.wickedsource.coderadar.analyzerconfig.domain.AnalyzerConfigurationRepository;
 import org.wickedsource.coderadar.commit.domain.Commit;
 import org.wickedsource.coderadar.commit.domain.CommitRepository;
 import org.wickedsource.coderadar.core.configuration.CoderadarConfiguration;
+import org.wickedsource.coderadar.filepattern.domain.FilePatternRepository;
 import org.wickedsource.coderadar.job.JobLogger;
 import org.wickedsource.coderadar.job.core.ProcessingStatus;
 
@@ -16,20 +20,30 @@ import org.wickedsource.coderadar.job.core.ProcessingStatus;
 @ConditionalOnProperty("coderadar.master")
 public class AnalyzeCommitJobTrigger {
 
+  private Logger logger = LoggerFactory.getLogger(AnalyzeCommitJobTrigger.class);
+
   private JobLogger jobLogger;
 
   private CommitRepository commitRepository;
 
   private AnalyzeCommitJobRepository analyzeCommitJobRepository;
 
+  private FilePatternRepository filePatternRepository;
+
+  private AnalyzerConfigurationRepository analyzerConfigurationRepository;
+
   @Autowired
   public AnalyzeCommitJobTrigger(
       JobLogger jobLogger,
       CommitRepository commitRepository,
-      AnalyzeCommitJobRepository analyzeCommitJobRepository) {
+      AnalyzeCommitJobRepository analyzeCommitJobRepository,
+      FilePatternRepository filePatternRepository,
+      AnalyzerConfigurationRepository analyzerConfigurationRepository) {
     this.jobLogger = jobLogger;
     this.commitRepository = commitRepository;
     this.analyzeCommitJobRepository = analyzeCommitJobRepository;
+    this.filePatternRepository = filePatternRepository;
+    this.analyzerConfigurationRepository = analyzerConfigurationRepository;
   }
 
   @Scheduled(fixedDelay = CoderadarConfiguration.TIMER_INTERVAL)
@@ -37,6 +51,23 @@ public class AnalyzeCommitJobTrigger {
     for (Commit commit :
         commitRepository.findCommitsToBeAnalyzed(
             Arrays.asList(ProcessingStatus.PROCESSING, ProcessingStatus.WAITING))) {
+
+      if (!hasFilePatternsConfigured(commit)) {
+        logger.debug(
+            "skipping commit {} because no file patterns are configured for project {}",
+            commit.getName(),
+            commit.getProject().getId());
+        continue;
+      }
+
+      if (!hasAnalyzerConfigured(commit)) {
+        logger.debug(
+            "skipping commit {} because no analyzers are configured for project {}",
+            commit.getName(),
+            commit.getProject().getId());
+        continue;
+      }
+
       AnalyzeCommitJob job = new AnalyzeCommitJob();
       job.setQueuedDate(new Date());
       job.setProcessingStatus(ProcessingStatus.WAITING);
@@ -45,5 +76,13 @@ public class AnalyzeCommitJobTrigger {
       analyzeCommitJobRepository.save(job);
       jobLogger.queuedNewJob(job, commit.getProject());
     }
+  }
+
+  private boolean hasFilePatternsConfigured(Commit commit) {
+    return filePatternRepository.countByProjectId(commit.getProject().getId()) > 0;
+  }
+
+  private boolean hasAnalyzerConfigured(Commit commit) {
+    return analyzerConfigurationRepository.countByProjectId(commit.getProject().getId()) > 0;
   }
 }


### PR DESCRIPTION
… configured for the project

AnalyzeCommitJob is no longer triggered when there are no analyzers configured for the project